### PR TITLE
Refactor story map updates

### DIFF
--- a/src/chapter.ts
+++ b/src/chapter.ts
@@ -1,23 +1,44 @@
 export class Chapter {
   r2: Record<string, string>;
+  story_title: string;
+  chapter_title: string;
   title: string;
   when_free: number;
   cost: number;
   version: number;
+  update_story_map: (
+    story_title: string,
+    chapter_title: string,
+    when_free: number,
+    version: number,
+  ) => void;
+  last_synced_version: number;
 
   constructor(
     r2: Record<string, string>,
-    title: string,
+    story_title: string,
+    chapter_title: string,
     when_free: number,
     cost: number,
     version: number = 0,
     text: string = "",
+    update_story_map: (
+      story_title: string,
+      chapter_title: string,
+      when_free: number,
+      version: number,
+    ) => void = () => {},
+    last_synced_version: number = version,
   ) {
     this.r2 = r2;
-    this.title = title;
+    this.story_title = story_title;
+    this.chapter_title = chapter_title;
+    this.title = `${story_title}:${chapter_title}`;
     this.when_free = when_free;
     this.cost = cost;
     this.version = version;
+    this.update_story_map = update_story_map;
+    this.last_synced_version = last_synced_version;
     if (text.length == 0) return;
     this.update(text);
   }
@@ -27,33 +48,62 @@ export class Chapter {
   update(new_text: string) {
     this.r2[`${this.title}:${this.version}`] = new_text;
     this.version += 1;
+    this.update_story_map(
+      this.story_title,
+      this.chapter_title,
+      this.when_free,
+      this.version,
+    );
+    this.last_synced_version = this.version;
   }
   key(version: number): string {
     return `${this.title}:${version}`;
   }
   serialize(): string {
     let saved_state: any = {
-      title: this.title,
+      story_title: this.story_title,
+      chapter_title: this.chapter_title,
       when_free: this.when_free,
       cost: this.cost,
       version: this.version,
+      last_synced_version: this.last_synced_version,
     };
     for (let i = 0; i < this.version; ++i) {
       saved_state[i] = this.r2[`${this.title}:${i}`];
     }
+    if (this.version > 0) {
+      saved_state[this.version] = this.r2[`${this.title}:${this.version - 1}`];
+    }
     return JSON.stringify(saved_state);
   }
-  static deserialize(r2: Record<string, string>, str: string): Chapter {
-    let saved_state = JSON.parse(str);
-    let chapter = new Chapter(
+  static deserialize(
+    r2: Record<string, string>,
+    str: string,
+    update_story_map: (
+      story_title: string,
+      chapter_title: string,
+      when_free: number,
+      version: number,
+    ) => void = () => {},
+  ): Chapter {
+    const saved_state = JSON.parse(str);
+    const chapter = new Chapter(
       r2,
-      saved_state.title,
+      saved_state.story_title,
+      saved_state.chapter_title,
       saved_state.when_free,
       saved_state.cost,
       saved_state.version,
+      "",
+      update_story_map,
+      saved_state.last_synced_version ?? saved_state.version,
     );
     for (let i = 0; i < chapter.version; ++i) {
       r2[`${chapter.title}:${i}`] = saved_state[i];
+    }
+    const latest_text = saved_state[saved_state.version];
+    if (latest_text !== undefined && chapter.version > 0) {
+      r2[`${chapter.title}:${chapter.version - 1}`] = latest_text;
     }
     return chapter;
   }

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -2,12 +2,26 @@ import { Chapter } from "~/chapter";
 
 export class Publisher {
   r2: Record<string, string>;
-  stories: Record<string, Chapter[]>;
+  stories: Record<string, Record<string, Chapter>>;
 
   constructor(r2: Record<string, string>) {
     this.r2 = r2;
     this.stories = {};
   }
+
+  update_story_map = (
+    story_title: string,
+    chapter_title: string,
+    when_free: number,
+    version: number,
+  ) => {
+    const story = this.stories[story_title];
+    if (!story) return;
+    const mapping: [string, number, number][] = Object.values(story).map(
+      (chapter) => [chapter.title, chapter.when_free, chapter.version],
+    );
+    this.r2[story_title] = JSON.stringify(mapping);
+  };
   publish_chapter(
     story_title: string,
     chapter_title: string,
@@ -15,22 +29,30 @@ export class Publisher {
     cost: number,
     text: string,
   ): Chapter {
-    let story = this.stories[story_title] || [];
-    const new_id = story.length;
+    let story = this.stories[story_title] || {};
     const chapter = new Chapter(
       this.r2,
-      `${story_title}:${chapter_title}`,
+      story_title,
+      chapter_title,
       when_free,
       cost,
       0,
-      text,
+      "",
+      this.update_story_map,
     );
-    story.push(chapter);
+    story[chapter_title] = chapter;
     this.stories[story_title] = story;
-    this.r2[story_title] = JSON.stringify(
-      /* TODO: Add chapter html link. */
-      story.map((chapter) => [chapter.title, chapter.when_free]),
-    );
+    if (text.length > 0) {
+      chapter.update(text);
+    } else {
+      this.update_story_map(
+        story_title,
+        chapter_title,
+        when_free,
+        chapter.version,
+      );
+      chapter.last_synced_version = chapter.version;
+    }
     return chapter;
   }
   serialize(): string {
@@ -38,7 +60,7 @@ export class Publisher {
     for (const [story_title, story] of Object.entries(this.stories).filter(
       ([k, v]) => !k.includes(":"),
     )) {
-      saved_state[story_title] = story.map((chapter): any =>
+      saved_state[story_title] = Object.values(story).map((chapter): any =>
         JSON.parse(chapter.serialize()),
       );
     }
@@ -50,9 +72,33 @@ export class Publisher {
     for (const [story_title, story] of Object.entries(saved_state).filter(
       ([k, v]) => !k.includes(":"),
     )) {
-      publisher.stories[story_title] = story.map((chapter: Chapter) =>
-        Chapter.deserialize(r2, JSON.stringify(chapter)),
-      );
+      publisher.stories[story_title] = {};
+      for (const chapter of story as any[]) {
+        const ch = Chapter.deserialize(
+          r2,
+          JSON.stringify(chapter),
+          publisher.update_story_map,
+        );
+        publisher.stories[story_title][ch.chapter_title] = ch;
+        const start = ch.last_synced_version;
+        for (let v = start; v < ch.version; v++) {
+          publisher.update_story_map(
+            story_title,
+            ch.chapter_title,
+            ch.when_free,
+            v + 1,
+          );
+          ch.last_synced_version = v + 1;
+        }
+        if (start === ch.last_synced_version) {
+          publisher.update_story_map(
+            story_title,
+            ch.chapter_title,
+            ch.when_free,
+            ch.version,
+          );
+        }
+      }
     }
     return publisher;
   }

--- a/tests/chapter.test.ts
+++ b/tests/chapter.test.ts
@@ -4,26 +4,43 @@ import { Chapter } from "~/chapter";
 describe("Chapter ", () => {
   test("contains nothing by default", () => {
     let r2: Record<string, string> = {};
-    let chapter = new Chapter(r2, "chapter", 9999999999, 200);
+    let chapter = new Chapter(r2, "story", "chapter", 9999999999, 200);
     expect(r2[chapter.key(0)]).toBeUndefined();
   });
   test("can add text as expected", () => {
     let r2: Record<string, string> = {};
-    let chapter = new Chapter(r2, "chapter", 9999999999, 200);
+    let chapter = new Chapter(r2, "story", "chapter", 9999999999, 200);
     expect(r2[chapter.key(0)]).toBeUndefined();
     expect(chapter.version).toBe(0);
     expect(chapter.cost).toBe(200);
-    expect(chapter.title).toBe("chapter");
+    expect(chapter.title).toBe("story:chapter");
+    expect(chapter.last_synced_version).toBe(0);
     chapter.update("text");
     expect(chapter.version).toBe(1);
+    expect(chapter.last_synced_version).toBe(1);
     expect(r2[chapter.key(0)]).toBe("text");
     expect(r2[chapter.key(1)]).toBeUndefined();
   });
   test("is_free math works", () => {
     let r2: Record<string, string> = {};
-    let chapter = new Chapter(r2, "chapter", 9999999999, 200);
+    let chapter = new Chapter(r2, "story", "chapter", 9999999999, 200);
     expect(chapter.is_free(0)).toBeFalsy();
-    chapter = new Chapter(r2, "chapter", 0, 200);
+    chapter = new Chapter(r2, "story", "chapter", 0, 200);
     expect(chapter.is_free(0)).toBeTruthy();
+  });
+  test("serialize stores separate story and chapter titles", () => {
+    let r2: Record<string, string> = {};
+    let chapter = new Chapter(r2, "story", "chapter", 0, 0);
+    chapter.update("text");
+    const saved = JSON.parse(chapter.serialize());
+    expect(saved.story_title).toBe("story");
+    expect(saved.chapter_title).toBe("chapter");
+    expect(saved).not.toHaveProperty("title");
+    expect(saved[saved.version]).toBe("text");
+
+    const reloaded = Chapter.deserialize(r2, chapter.serialize());
+    expect(reloaded.story_title).toBe("story");
+    expect(reloaded.chapter_title).toBe("chapter");
+    expect(r2[reloaded.key(reloaded.version - 1)]).toBe("text");
   });
 });

--- a/tests/publisher.test.ts
+++ b/tests/publisher.test.ts
@@ -21,12 +21,16 @@ describe("Publisher", () => {
     let r2: Record<string, string> = {};
     let publisher = new Publisher(r2);
     const chapter = publisher.publish_chapter("story", "chapter", 0, 0, "blah");
+    expect(chapter.last_synced_version).toBe(1);
     chapter.update("blah2");
+    expect(chapter.last_synced_version).toBe(2);
 
     expect(Object.keys(r2).filter((x) => !x.includes(":"))).toStrictEqual([
       "story",
     ]);
     expect(Object.keys(r2).length).toBe(3);
+    const mapping = JSON.parse(r2["story"]!);
+    expect(mapping).toStrictEqual([["story:chapter", 0, 2]]);
   });
   test("R2 creates a key for a story with multiple chapters", () => {
     let r2: Record<string, string> = {};
@@ -35,6 +39,11 @@ describe("Publisher", () => {
     publisher.publish_chapter("story", "chapter 2", 0, 0, "blah");
     expect(Object.keys(r2).filter((x) => !x.includes(":"))).toStrictEqual([
       "story",
+    ]);
+    const mapping = JSON.parse(r2["story"]!);
+    expect(mapping).toStrictEqual([
+      ["story:chapter", 0, 1],
+      ["story:chapter 2", 0, 1],
     ]);
   });
   test("R2 creates a keys for two stories", () => {
@@ -47,6 +56,10 @@ describe("Publisher", () => {
         .filter((x) => !x.includes(":"))
         .sort(),
     ).toStrictEqual(["story", "story 2"]);
+    const story1 = JSON.parse(r2["story"]!);
+    const story2 = JSON.parse(r2["story 2"]!);
+    expect(story1).toStrictEqual([["story:chapter", 0, 1]]);
+    expect(story2).toStrictEqual([["story 2:chapter", 0, 1]]);
   });
   test("Can reload from encoded R2", () => {
     let r2: Record<string, string> = {};
@@ -56,6 +69,42 @@ describe("Publisher", () => {
     publisher.publish_chapter("story 2", "chapter", 0, 0, "blah");
     let publisher2 = Publisher.deserialize(r2, publisher.serialize());
 
-    expect(publisher.stories).toStrictEqual(publisher2.stories);
+    for (const [title, story] of Object.entries(publisher.stories)) {
+      const story2 = publisher2.stories[title]!;
+      expect(Object.keys(story2).length).toBe(Object.keys(story).length);
+      for (const [chapterTitle, chapter] of Object.entries(story)) {
+        const chapter2 = story2[chapterTitle]!;
+        expect(chapter2.title).toBe(chapter.title);
+        expect(chapter2.when_free).toBe(chapter.when_free);
+        expect(chapter2.cost).toBe(chapter.cost);
+        expect(chapter2.version).toBe(chapter.version);
+      }
+    }
+    for (const story of Object.values(publisher2.stories)) {
+      Object.values(story).forEach((c) =>
+        expect(c.last_synced_version).toBe(c.version),
+      );
+    }
+    expect(JSON.parse(r2["story"]!)).toStrictEqual([
+      ["story:chapter", 0, 1],
+      ["story:chapter 2", 0, 1],
+    ]);
+    expect(JSON.parse(r2["story 2"]!)).toStrictEqual([
+      ["story 2:chapter", 0, 1],
+    ]);
+  });
+  test("deserialization syncs missing versions", () => {
+    let r2: Record<string, string> = {};
+    let publisher = new Publisher(r2);
+    const chapter = publisher.publish_chapter("story", "chapter", 0, 0, "v1");
+    chapter.update("v2");
+    const saved = JSON.parse(publisher.serialize());
+    saved["story"][0].last_synced_version = 1;
+    let r2b: Record<string, string> = {};
+    const publisher2 = Publisher.deserialize(r2b, JSON.stringify(saved));
+    const mapping = JSON.parse(r2b["story"]!);
+    expect(mapping).toStrictEqual([["story:chapter", 0, 2]]);
+    const ch2 = publisher2.stories["story"]!["chapter"]!;
+    expect(ch2.last_synced_version).toBe(2);
   });
 });

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -16,9 +16,9 @@ describe("User", () => {
 });
 describe("User ownership", () => {
   let r2 = {};
-  let expired_chapter = new Chapter(r2, "expired", 0, 3);
-  let active_chapter = new Chapter(r2, "active", 9999999999, 1);
-  let expensive_chapter = new Chapter(r2, "active", 9999999999, 50);
+  let expired_chapter = new Chapter(r2, "story", "expired", 0, 3);
+  let active_chapter = new Chapter(r2, "story", "active", 9999999999, 1);
+  let expensive_chapter = new Chapter(r2, "story", "expensive", 9999999999, 50);
 
   test("owns expired chapters for free", () => {
     let user = new User(new Set());


### PR DESCRIPTION
## Summary
- Serialize each chapter with its latest text and restore it during deserialization
- Sync unsynced chapter versions to the story map when publishers deserialize

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae56fd09b08331959f27b6065120d6