### PR TITLE
Render chapter markdown to HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "lightnovel",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "marked": "^16.2.0"
+      },
       "devDependencies": {
         "@types/node": "^24.3.0",
         "@vitest/coverage-istanbul": "^3.2.4",
@@ -1865,6 +1868,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.2.0.tgz",
+      "integrity": "sha512-LbbTuye+0dWRz2TS9KJ7wsnD4KAtpj0MVkWc90XvBa6AslXsT0hTBVH5k32pcSyHH1fst9XEFJunXHktVy0zlg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "@vitest/coverage-istanbul": "^3.2.4",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"
+  },
+  "dependencies": {
+    "marked": "^16.2.0"
   }
 }

--- a/src/chapter.ts
+++ b/src/chapter.ts
@@ -1,3 +1,5 @@
+import { marked } from "marked";
+
 export class Chapter {
   r2: Record<string, string>;
   story_title: string;
@@ -46,7 +48,9 @@ export class Chapter {
     return now >= this.when_free;
   }
   update(new_text: string) {
-    this.r2[`${this.title}:${this.version}`] = new_text;
+    const key = `${this.title}:${this.version}`;
+    this.r2[key] = new_text;
+    this.r2[`${key}.html`] = marked.parse(new_text, { async: false });
     this.version += 1;
     this.update_story_map(
       this.story_title,
@@ -100,10 +104,17 @@ export class Chapter {
     );
     for (let i = 0; i < chapter.version; ++i) {
       r2[`${chapter.title}:${i}`] = saved_state[i];
+      r2[`${chapter.title}:${i}.html`] = marked.parse(saved_state[i], {
+        async: false,
+      });
     }
     const latest_text = saved_state[saved_state.version];
     if (latest_text !== undefined && chapter.version > 0) {
       r2[`${chapter.title}:${chapter.version - 1}`] = latest_text;
+      r2[`${chapter.title}:${chapter.version - 1}.html`] = marked.parse(
+        latest_text,
+        { async: false },
+      );
     }
     return chapter;
   }

--- a/tests/chapter.test.ts
+++ b/tests/chapter.test.ts
@@ -15,10 +15,11 @@ describe("Chapter ", () => {
     expect(chapter.cost).toBe(200);
     expect(chapter.title).toBe("story:chapter");
     expect(chapter.last_synced_version).toBe(0);
-    chapter.update("text");
+    chapter.update("# text");
     expect(chapter.version).toBe(1);
     expect(chapter.last_synced_version).toBe(1);
-    expect(r2[chapter.key(0)]).toBe("text");
+    expect(r2[chapter.key(0)]).toBe("# text");
+    expect(r2[chapter.key(0) + ".html"]).toBe("<h1>text</h1>\n");
     expect(r2[chapter.key(1)]).toBeUndefined();
   });
   test("is_free math works", () => {
@@ -31,16 +32,19 @@ describe("Chapter ", () => {
   test("serialize stores separate story and chapter titles", () => {
     let r2: Record<string, string> = {};
     let chapter = new Chapter(r2, "story", "chapter", 0, 0);
-    chapter.update("text");
+    chapter.update("# text");
     const saved = JSON.parse(chapter.serialize());
     expect(saved.story_title).toBe("story");
     expect(saved.chapter_title).toBe("chapter");
     expect(saved).not.toHaveProperty("title");
-    expect(saved[saved.version]).toBe("text");
+    expect(saved[saved.version]).toBe("# text");
 
     const reloaded = Chapter.deserialize(r2, chapter.serialize());
     expect(reloaded.story_title).toBe("story");
     expect(reloaded.chapter_title).toBe("chapter");
-    expect(r2[reloaded.key(reloaded.version - 1)]).toBe("text");
+    expect(r2[reloaded.key(reloaded.version - 1)]).toBe("# text");
+    expect(r2[reloaded.key(reloaded.version - 1) + ".html"]).toBe(
+      "<h1>text</h1>\n",
+    );
   });
 });

--- a/tests/publisher.test.ts
+++ b/tests/publisher.test.ts
@@ -28,7 +28,9 @@ describe("Publisher", () => {
     expect(Object.keys(r2).filter((x) => !x.includes(":"))).toStrictEqual([
       "story",
     ]);
-    expect(Object.keys(r2).length).toBe(3);
+    expect(Object.keys(r2).length).toBe(5);
+    expect(r2["story:chapter:0.html"]).toBe("<p>blah</p>\n");
+    expect(r2["story:chapter:1.html"]).toBe("<p>blah2</p>\n");
     const mapping = JSON.parse(r2["story"]!);
     expect(mapping).toStrictEqual([["story:chapter", 0, 2]]);
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,7 @@
     "baseUrl": ".",
     "paths": {
       "~/*": ["./src/*"],
-      "@/*": ["./src/*"],
+      "@/*": ["./src/*"]
     },
     "esModuleInterop": true,
   },


### PR DESCRIPTION
## Summary
- install official `marked` package and remove in-project parser
- render chapter markdown to HTML with `marked.parse`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae8937cb688331994d68b3439d9f64