### PR TITLE
refactor: model R2 storage interface for Cloudflare workers

### DIFF
--- a/src/chapter.ts
+++ b/src/chapter.ts
@@ -1,7 +1,8 @@
 import { marked } from "marked";
+import type { R2Bucket } from "~/r2";
 
 export class Chapter {
-  r2: Record<string, string>;
+  r2: R2Bucket;
   story_title: string;
   chapter_title: string;
   title: string;
@@ -13,23 +14,22 @@ export class Chapter {
     chapter_title: string,
     when_free: number,
     version: number,
-  ) => void;
+  ) => Promise<void>;
   last_synced_version: number;
 
   constructor(
-    r2: Record<string, string>,
+    r2: R2Bucket,
     story_title: string,
     chapter_title: string,
     when_free: number,
     cost: number,
     version: number = 0,
-    text: string = "",
     update_story_map: (
       story_title: string,
       chapter_title: string,
       when_free: number,
       version: number,
-    ) => void = () => {},
+    ) => Promise<void> = async () => {},
     last_synced_version: number = version,
   ) {
     this.r2 = r2;
@@ -41,18 +41,16 @@ export class Chapter {
     this.version = version;
     this.update_story_map = update_story_map;
     this.last_synced_version = last_synced_version;
-    if (text.length == 0) return;
-    this.update(text);
   }
   is_free(now: number): boolean {
     return now >= this.when_free;
   }
-  update(new_text: string) {
+  async update(new_text: string) {
     const key = `${this.title}:${this.version}`;
-    this.r2[key] = new_text;
-    this.r2[`${key}.html`] = marked.parse(new_text, { async: false });
+    await this.r2.put(key, new_text);
+    await this.r2.put(`${key}.html`, marked.parse(new_text, { async: false }));
     this.version += 1;
-    this.update_story_map(
+    await this.update_story_map(
       this.story_title,
       this.chapter_title,
       this.when_free,
@@ -63,7 +61,7 @@ export class Chapter {
   key(version: number): string {
     return `${this.title}:${version}`;
   }
-  serialize(): string {
+  async serialize(): Promise<string> {
     let saved_state: any = {
       story_title: this.story_title,
       chapter_title: this.chapter_title,
@@ -73,23 +71,25 @@ export class Chapter {
       last_synced_version: this.last_synced_version,
     };
     for (let i = 0; i < this.version; ++i) {
-      saved_state[i] = this.r2[`${this.title}:${i}`];
+      const obj = await this.r2.get(`${this.title}:${i}`);
+      saved_state[i] = obj ? await obj.text() : undefined;
     }
     if (this.version > 0) {
-      saved_state[this.version] = this.r2[`${this.title}:${this.version - 1}`];
+      const obj = await this.r2.get(`${this.title}:${this.version - 1}`);
+      saved_state[this.version] = obj ? await obj.text() : undefined;
     }
     return JSON.stringify(saved_state);
   }
-  static deserialize(
-    r2: Record<string, string>,
+  static async deserialize(
+    r2: R2Bucket,
     str: string,
     update_story_map: (
       story_title: string,
       chapter_title: string,
       when_free: number,
       version: number,
-    ) => void = () => {},
-  ): Chapter {
+    ) => Promise<void> = async () => {},
+  ): Promise<Chapter> {
     const saved_state = JSON.parse(str);
     const chapter = new Chapter(
       r2,
@@ -98,22 +98,23 @@ export class Chapter {
       saved_state.when_free,
       saved_state.cost,
       saved_state.version,
-      "",
       update_story_map,
       saved_state.last_synced_version ?? saved_state.version,
     );
     for (let i = 0; i < chapter.version; ++i) {
-      r2[`${chapter.title}:${i}`] = saved_state[i];
-      r2[`${chapter.title}:${i}.html`] = marked.parse(saved_state[i], {
-        async: false,
-      });
+      const text = saved_state[i];
+      await r2.put(`${chapter.title}:${i}`, text);
+      await r2.put(
+        `${chapter.title}:${i}.html`,
+        marked.parse(text, { async: false }),
+      );
     }
     const latest_text = saved_state[saved_state.version];
     if (latest_text !== undefined && chapter.version > 0) {
-      r2[`${chapter.title}:${chapter.version - 1}`] = latest_text;
-      r2[`${chapter.title}:${chapter.version - 1}.html`] = marked.parse(
-        latest_text,
-        { async: false },
+      await r2.put(`${chapter.title}:${chapter.version - 1}`, latest_text);
+      await r2.put(
+        `${chapter.title}:${chapter.version - 1}.html`,
+        marked.parse(latest_text, { async: false }),
       );
     }
     return chapter;

--- a/src/r2.ts
+++ b/src/r2.ts
@@ -1,0 +1,38 @@
+export interface R2Object {
+  text(): Promise<string>;
+}
+
+export interface R2Bucket {
+  get(key: string): Promise<R2Object | null>;
+  put(key: string, value: string): Promise<void>;
+  list(options?: { prefix?: string }): Promise<{ objects: { key: string }[] }>;
+}
+
+export class MemoryR2Bucket implements R2Bucket {
+  private store: Map<string, string>;
+
+  constructor(initial: Record<string, string> = {}) {
+    this.store = new Map(Object.entries(initial));
+  }
+
+  async get(key: string): Promise<R2Object | null> {
+    if (!this.store.has(key)) return null;
+    const value = this.store.get(key)!;
+    return {
+      text: async () => value,
+    };
+  }
+
+  async put(key: string, value: string): Promise<void> {
+    this.store.set(key, value);
+  }
+
+  async list(options?: { prefix?: string }): Promise<{ objects: { key: string }[] }> {
+    const objects: { key: string }[] = [];
+    for (const key of this.store.keys()) {
+      if (options?.prefix && !key.startsWith(options.prefix)) continue;
+      objects.push({ key });
+    }
+    return { objects };
+  }
+}

--- a/tests/chapter.test.ts
+++ b/tests/chapter.test.ts
@@ -1,50 +1,57 @@
 import { describe, expect, test } from "vitest";
 import { Chapter } from "~/chapter";
+import { MemoryR2Bucket } from "~/r2";
 
 describe("Chapter ", () => {
-  test("contains nothing by default", () => {
-    let r2: Record<string, string> = {};
+  test("contains nothing by default", async () => {
+    let r2 = new MemoryR2Bucket();
     let chapter = new Chapter(r2, "story", "chapter", 9999999999, 200);
-    expect(r2[chapter.key(0)]).toBeUndefined();
+    expect(await r2.get(chapter.key(0))).toBeNull();
   });
-  test("can add text as expected", () => {
-    let r2: Record<string, string> = {};
+  test("can add text as expected", async () => {
+    let r2 = new MemoryR2Bucket();
     let chapter = new Chapter(r2, "story", "chapter", 9999999999, 200);
-    expect(r2[chapter.key(0)]).toBeUndefined();
+    expect(await r2.get(chapter.key(0))).toBeNull();
     expect(chapter.version).toBe(0);
     expect(chapter.cost).toBe(200);
     expect(chapter.title).toBe("story:chapter");
     expect(chapter.last_synced_version).toBe(0);
-    chapter.update("# text");
+    await chapter.update("# text");
     expect(chapter.version).toBe(1);
     expect(chapter.last_synced_version).toBe(1);
-    expect(r2[chapter.key(0)]).toBe("# text");
-    expect(r2[chapter.key(0) + ".html"]).toBe("<h1>text</h1>\n");
-    expect(r2[chapter.key(1)]).toBeUndefined();
+    expect(await (await r2.get(chapter.key(0)))?.text()).toBe("# text");
+    expect(await (await r2.get(chapter.key(0) + ".html"))?.text()).toBe(
+      "<h1>text</h1>\n",
+    );
+    expect(await r2.get(chapter.key(1))).toBeNull();
   });
   test("is_free math works", () => {
-    let r2: Record<string, string> = {};
+    let r2 = new MemoryR2Bucket();
     let chapter = new Chapter(r2, "story", "chapter", 9999999999, 200);
     expect(chapter.is_free(0)).toBeFalsy();
     chapter = new Chapter(r2, "story", "chapter", 0, 200);
     expect(chapter.is_free(0)).toBeTruthy();
   });
-  test("serialize stores separate story and chapter titles", () => {
-    let r2: Record<string, string> = {};
+  test("serialize stores separate story and chapter titles", async () => {
+    let r2 = new MemoryR2Bucket();
     let chapter = new Chapter(r2, "story", "chapter", 0, 0);
-    chapter.update("# text");
-    const saved = JSON.parse(chapter.serialize());
+    await chapter.update("# text");
+    const saved = JSON.parse(await chapter.serialize());
     expect(saved.story_title).toBe("story");
     expect(saved.chapter_title).toBe("chapter");
     expect(saved).not.toHaveProperty("title");
     expect(saved[saved.version]).toBe("# text");
 
-    const reloaded = Chapter.deserialize(r2, chapter.serialize());
+    const reloaded = await Chapter.deserialize(r2, await chapter.serialize());
     expect(reloaded.story_title).toBe("story");
     expect(reloaded.chapter_title).toBe("chapter");
-    expect(r2[reloaded.key(reloaded.version - 1)]).toBe("# text");
-    expect(r2[reloaded.key(reloaded.version - 1) + ".html"]).toBe(
-      "<h1>text</h1>\n",
+    expect(await (await r2.get(reloaded.key(reloaded.version - 1)))?.text()).toBe(
+      "# text",
     );
+    expect(
+      await (
+        await r2.get(reloaded.key(reloaded.version - 1) + ".html")
+      )?.text(),
+    ).toBe("<h1>text</h1>\n");
   });
 });

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import { Chapter } from "~/chapter";
 import { User } from "~/user";
+import { MemoryR2Bucket } from "~/r2";
 
 describe("User", () => {
   test("defaults to zero credits", () => {
@@ -15,7 +16,7 @@ describe("User", () => {
   });
 });
 describe("User ownership", () => {
-  let r2 = {};
+  let r2 = new MemoryR2Bucket();
   let expired_chapter = new Chapter(r2, "story", "expired", 0, 3);
   let active_chapter = new Chapter(r2, "story", "active", 9999999999, 1);
   let expensive_chapter = new Chapter(r2, "story", "expensive", 9999999999, 50);


### PR DESCRIPTION
## Summary
- add in-memory R2 bucket with get/put/list APIs
- refactor Chapter and Publisher to use async R2 interface
- update tests to exercise new R2 behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae9504a2c0833197fe40a522d4156e