### PR TITLE
feat: add translator interface and stub

### DIFF
--- a/src/translator.ts
+++ b/src/translator.ts
@@ -1,0 +1,27 @@
+export interface Translator {
+  translateChapter(input: { title: string; body: string }): Promise<{ title: string; body: string }>;
+}
+
+export class MockTranslator implements Translator {
+  async translateChapter(input: { title: string; body: string }): Promise<{ title: string; body: string }> {
+    return input;
+  }
+}
+
+export class DeepSeekTranslator implements Translator {
+  apiKey: string;
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+  async translateChapter(input: { title: string; body: string }): Promise<{ title: string; body: string }> {
+    const resp = await fetch("https://api.deepseek.com/translate", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify(input),
+    });
+    return (await resp.json()) as { title: string; body: string };
+  }
+}


### PR DESCRIPTION
## Summary
- define `Translator` interface
- add `MockTranslator` for returning original text
- introduce `DeepSeekTranslator` stub that posts to DeepSeek API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af8a40e79483319dbb4720f2fd1d4b